### PR TITLE
Replace deprecated alias Zmod with Z.modulo

### DIFF
--- a/implementations/stdlib_binary_integers.v
+++ b/implementations/stdlib_binary_integers.v
@@ -261,7 +261,7 @@ Qed.
 #[global]
 Instance Z_div: DivEuclid Z := Z.div.
 #[global]
-Instance Z_mod: ModEuclid Z := Zmod.
+Instance Z_mod: ModEuclid Z := Z.modulo.
 
 #[global]
 Instance: EuclidSpec Z _ _.


### PR DESCRIPTION
This change adapts math-classes for a future stdlib PR removing Zmod.

The current definition of `Zmod` in stdlib is as follows:

```
#[deprecated(since="8.17",note="Use Coq.ZArith.BinIntDef.Z.modulo instead")]
Notation Zmod := Z.modulo (only parsing).
```

I am looking to remove that definition shortly, and to reuse the name for something incompatible.

Thanks!